### PR TITLE
Fix the error

### DIFF
--- a/randominfo/__init__.py
+++ b/randominfo/__init__.py
@@ -269,7 +269,11 @@ def get_address():
 					allAddrs.append(addr[i])
 			except:
 				pass
-		full_addr.append(choice(allAddrs))
+		# Checking that the allAddrs list is not empty before selecting an element
+		if allAddrs:
+			full_addr.append(choice(allAddrs))
+		else:
+			full_addr.append("Information not available")
 	full_addr = dict(zip(addrParam, full_addr))
 	return full_addr
 


### PR DESCRIPTION
The error is related to an attempt to select a random element from an empty sequence using the random.choice() function. This happens in the randominfo code in the __init__.py file on line 272, where the choice(allAddrs) function is used. The allAddrs list is empty, which causes the error "Cannot choose from an empty sequence"